### PR TITLE
Fix CI: update test mocks for removed query slicing and fix Black for…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install linters
-        run: pip install black==24.* ruff==0.8.*
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
 
       - name: Check formatting
-        run: black --check src/ tests/
+        run: uv run black --check src/ tests/
 
       - name: Run linter
-        run: ruff check src/ tests/
+        run: uv run ruff check src/ tests/
 
   test:
     runs-on: ubuntu-latest

--- a/src/cs_copilot/agents/config.py
+++ b/src/cs_copilot/agents/config.py
@@ -6,7 +6,6 @@ Contains path constants and database configuration settings.
 Agent instructions and prompts are now in prompts.py.
 """
 
-
 # Database Configuration
 CS_COPILOT_MEMORY_DB = "cs_copilot_memory.db"
 CS_COPILOT_MEMORY_TABLE = "cs_copilot_memory"

--- a/src/cs_copilot/tools/analysis/robustness_toolkit.py
+++ b/src/cs_copilot/tools/analysis/robustness_toolkit.py
@@ -494,7 +494,8 @@ class RobustnessAnalysisToolkit(Toolkit):
                 )
             if comp.get("process_consistency", 1) < 0.80:
                 insights.append(
-                    "⚠️  Process inconsistency detected. " "Tool call sequences vary across prompts."
+                    "⚠️  Process inconsistency detected. "
+                    "Tool call sequences vary across prompts."
                 )
 
         # Generic recommendations

--- a/src/cs_copilot/tools/databases/chembl.py
+++ b/src/cs_copilot/tools/databases/chembl.py
@@ -383,7 +383,7 @@ class ChemblToolkit(BaseDatabaseToolkit):
                 activity_query = client.activity.filter(**activity_filter_kwargs).only(
                     self.ACTIVITY_FIELDS
                 )
-                
+
                 activities = list(activity_query)
 
                 if not activities:

--- a/src/cs_copilot/tools/io/pointer_pandas_tools.py
+++ b/src/cs_copilot/tools/io/pointer_pandas_tools.py
@@ -596,7 +596,7 @@ class PointerPandasTools(PandasTools):
                     columns = _coerce_columns(params.pop("column"), param_name="column")
                     value = params.get("value")
                     if not isinstance(value, dict):
-                        params["value"] = {c: value for c in columns}
+                        params["value"] = dict.fromkeys(columns, value)
 
             if operation == "select":
                 columns = params.get("columns", params.get("column"))

--- a/tests/robustness/robustness_minimal_example.py
+++ b/tests/robustness/robustness_minimal_example.py
@@ -774,7 +774,9 @@ class RobustnessRunner:
                     "✅ **Good robustness.** Minor inconsistencies but acceptable for production.\n"
                 )
             elif avg_score >= 0.7:
-                report += "⚠️ **Acceptable robustness** but room for improvement. Monitor closely.\n"
+                report += (
+                    "⚠️ **Acceptable robustness** but room for improvement. Monitor closely.\n"
+                )
             else:
                 report += "❌ **Concerning robustness.** Significant inconsistencies detected. Review agent prompts and tool implementations.\n"
 

--- a/tests/unit/test_databases/test_base.py
+++ b/tests/unit/test_databases/test_base.py
@@ -4,7 +4,6 @@
 Tests for the base database toolkit.
 """
 
-
 from cs_copilot.tools.databases.base import (
     BaseDatabaseToolkit,
     DatabaseError,

--- a/tests/unit/test_databases/test_chembl.py
+++ b/tests/unit/test_databases/test_chembl.py
@@ -297,9 +297,7 @@ class TestChemblToolkit:
         mock_client = Mock()
         # Mock assay search
         mock_assays = [{"assay_chembl_id": "CHEMBL1"}, {"assay_chembl_id": "CHEMBL2"}]
-        mock_assay_query = MagicMock()
-        mock_assay_query.__getitem__.return_value = mock_assays
-        mock_client.assay.filter.return_value = mock_assay_query
+        mock_client.assay.filter.return_value = mock_assays
 
         # Mock activity search
         mock_activities = [
@@ -347,9 +345,7 @@ class TestChemblToolkit:
         # Mock ChEMBL client
         mock_client = Mock()
         # Mock empty assay search
-        mock_assay_query = MagicMock()
-        mock_assay_query.__getitem__.return_value = []
-        mock_client.assay.filter.return_value = mock_assay_query
+        mock_client.assay.filter.return_value = []
         mock_ensure_client.return_value = mock_client
 
         toolkit = ChemblToolkit()
@@ -365,9 +361,7 @@ class TestChemblToolkit:
 
         mock_client = Mock()
         mock_assays = [{"assay_chembl_id": "CHEMBL1"}, {"assay_chembl_id": "CHEMBL2"}]
-        mock_assay_query = MagicMock()
-        mock_assay_query.__getitem__.return_value = mock_assays
-        mock_client.assay.filter.return_value = mock_assay_query
+        mock_client.assay.filter.return_value = mock_assays
 
         mock_activities = [
             {
@@ -441,9 +435,7 @@ class TestChemblToolkit:
         # Mock ChEMBL client
         mock_client = Mock()
         mock_assays = [{"assay_chembl_id": "CHEMBL1"}]
-        mock_assay_query = MagicMock()
-        mock_assay_query.__getitem__.return_value = mock_assays
-        mock_client.assay.filter.return_value = mock_assay_query
+        mock_client.assay.filter.return_value = mock_assays
 
         mock_activities = [
             {
@@ -814,9 +806,7 @@ class TestChemblIntegration:
         # Mock the full ChEMBL API workflow
         mock_client = Mock()
         mock_assays = [{"assay_chembl_id": "CHEMBL1"}]
-        mock_assay_query = MagicMock()
-        mock_assay_query.__getitem__.return_value = mock_assays
-        mock_client.assay.filter.return_value = mock_assay_query
+        mock_client.assay.filter.return_value = mock_assays
 
         mock_activities = [
             {

--- a/tests/unit/test_databases/test_chembl.py
+++ b/tests/unit/test_databases/test_chembl.py
@@ -542,7 +542,7 @@ class TestChemblToolkit:
             return original_save(df, query)
 
         toolkit._save_chembl_data = capture_save
-        result = toolkit.fetch_compounds("cdk2, kinase")
+        toolkit.fetch_compounds("cdk2, kinase")
 
         assert len(saved_dfs) == 1
         df = saved_dfs[0]


### PR DESCRIPTION
…matting

Tests mocked assay.filter with __getitem__ to handle the [:1000] slice that was removed in bcb5a12. Now return lists directly, matching the current code path. Also ran Black on 5 files with formatting violations.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement / refactor
- [ ] Documentation
- [ ] Tests
- [ ] CI / infrastructure

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `uv run pytest tests/unit/ -v` passes
- [ ] Tested manually (describe below)

<!-- If applicable, describe how you tested the changes -->
