### PR TITLE
Add letter→digit boundary splitting for single-token abbreviations

### DIFF
--- a/src/cs_copilot/tools/databases/chembl.py
+++ b/src/cs_copilot/tools/databases/chembl.py
@@ -23,28 +23,38 @@ from .types import DBConfig, PaginationMode, QueryParams, ResultPage
 # Any run of hyphens or whitespace counts as a single token separator.
 _HYPHEN_OR_SPACE_RUN = re.compile(r"[-\s]+")
 
+# Letter→digit boundary (e.g. "CDK2" → "CDK|2", "PDE4A" → "PDE|4A").
+# Only splits where a letter is immediately followed by a digit; the
+# digit and any trailing letters stay together as one unit.
+_LETTER_DIGIT_BOUNDARY = re.compile(r"(?<=[a-zA-Z])(?=\d)")
+
 
 def _build_punctuation_regex(keyword: str) -> str | None:
     """Build a regex that matches all hyphen/space variants of *keyword*.
 
-    Returns ``None`` for single-token inputs (no separators to vary),
-    signalling the caller to use plain substring matching.
+    Returns ``None`` when the keyword cannot be split into multiple
+    parts, signalling the caller to use plain substring matching.
 
-    **Symmetry guarantee**: inputs that tokenize identically via
-    ``_HYPHEN_OR_SPACE_RUN`` produce the same regex.  In particular::
+    **Two splitting passes**:
 
-        _build_punctuation_regex("cyclin-dependent kinase 2")
-        == _build_punctuation_regex("cyclin dependent kinase 2")
-        == _build_punctuation_regex("cyclin-dependent kinase-2")
+    1. Split on explicit hyphens/spaces (``_HYPHEN_OR_SPACE_RUN``).
+    2. Sub-split each resulting token at letter→digit boundaries
+       (``_LETTER_DIGIT_BOUNDARY``), so ``"CDK2"`` → ``["CDK", "2"]``
+       and ``"PDE4A"`` → ``["PDE", "4A"]``.
 
-    For *n* ≤ 3 tokens the separator is ``[- ]?`` (optional), covering
-    the concat form (e.g. ``"5HT2A"`` from ``"5-HT2A"``).
+    This means single-token abbreviations like ``CDK2`` now produce a
+    regex (``CDK[- ]?2``) that matches ``CDK2``, ``CDK-2``, and
+    ``CDK 2``.
+
+    **Symmetry guarantee**: inputs that tokenize identically across both
+    passes produce the same regex.
+
+    For *n* ≤ 3 final tokens the separator is ``[- ]?`` (optional),
+    covering the concat form (e.g. ``"CDK2"`` from ``"CDK-2"``).
     For *n* ≥ 4 tokens the separator is ``[- ]`` (required).
 
     Uses ``[- ]`` (literal hyphen + space) rather than ``[-\\s]`` for
-    maximum SQL dialect compatibility (MySQL 5.7 Henry Spencer regex
-    does not support ``\\s``).  ChEMBL assay descriptions never contain
-    tabs or newlines between tokens.
+    maximum SQL dialect compatibility.
 
     Each token is ``re.escape``'d to handle metacharacters.
     """
@@ -53,8 +63,19 @@ def _build_punctuation_regex(keyword: str) -> str | None:
     base = keyword.strip()
     if not base:
         return None
-    tokens = [t for t in _HYPHEN_OR_SPACE_RUN.split(base) if t]
-    if not tokens or len(tokens) == 1:
+
+    # Pass 1: split on explicit hyphens/spaces.
+    raw_tokens = [t for t in _HYPHEN_OR_SPACE_RUN.split(base) if t]
+    if not raw_tokens:
+        return None
+
+    # Pass 2: sub-split each token at letter→digit boundaries.
+    tokens: list[str] = []
+    for t in raw_tokens:
+        parts = _LETTER_DIGIT_BOUNDARY.split(t)
+        tokens.extend(p for p in parts if p)
+
+    if len(tokens) <= 1:
         return None
     escaped = [re.escape(t) for t in tokens]
     sep = "[- ]?" if len(tokens) <= 3 else "[- ]"

--- a/tests/unit/test_databases/test_chembl.py
+++ b/tests/unit/test_databases/test_chembl.py
@@ -986,14 +986,16 @@ class TestPunctuationRegex:
         assert re.search(p, "serotonin2A", re.IGNORECASE)
 
     def test_compact_5ht2a(self):
-        """Hyphen-separated compact names like 5-HT2A produce optional-sep regex."""
+        """Hyphen-separated compact names like 5-HT2A sub-split at letter→digit."""
         from cs_copilot.tools.databases.chembl import _build_punctuation_regex
 
         p = _build_punctuation_regex("5-HT2A")
-        assert p == r"5[- ]?HT2A"
+        # "HT2A" sub-splits to ["HT", "2A"] → 3 total tokens → optional sep
+        assert p == r"5[- ]?HT[- ]?2A"
         assert re.search(p, "5-HT2A")
         assert re.search(p, "5 HT2A")
         assert re.search(p, "5HT2A")
+        assert re.search(p, "5-HT-2A")
 
     def test_three_token_optional_separator(self):
         """3-token phrases also use optional separator."""
@@ -1005,13 +1007,39 @@ class TestPunctuationRegex:
         assert re.search(p, "B Raf kinase")
         assert re.search(p, "BRafkinase")
 
-    def test_single_token_returns_none(self):
-        """Single-token inputs return None (caller uses plain icontains)."""
+    def test_single_token_no_boundary_returns_none(self):
+        """All-letter tokens with no letter→digit boundary return None."""
         from cs_copilot.tools.databases.chembl import _build_punctuation_regex
 
         assert _build_punctuation_regex("EGFR") is None
         assert _build_punctuation_regex("BRAF") is None
-        assert _build_punctuation_regex("PDE4A") is None
+        assert _build_punctuation_regex("kinase") is None
+
+    def test_single_token_letter_digit_split(self):
+        """Single tokens with letter→digit boundaries produce a regex."""
+        from cs_copilot.tools.databases.chembl import _build_punctuation_regex
+
+        # CDK2 → ["CDK", "2"] → CDK[- ]?2
+        p = _build_punctuation_regex("CDK2")
+        assert p == r"CDK[- ]?2"
+        assert re.search(p, "CDK2", re.IGNORECASE)
+        assert re.search(p, "CDK-2", re.IGNORECASE)
+        assert re.search(p, "CDK 2", re.IGNORECASE)
+
+        # PDE4A → ["PDE", "4A"] → PDE[- ]?4A
+        p = _build_punctuation_regex("PDE4A")
+        assert p == r"PDE[- ]?4A"
+        assert re.search(p, "PDE4A", re.IGNORECASE)
+        assert re.search(p, "PDE-4A", re.IGNORECASE)
+        assert re.search(p, "PDE 4A", re.IGNORECASE)
+
+        # JAK2 → ["JAK", "2"]
+        p = _build_punctuation_regex("JAK2")
+        assert p == r"JAK[- ]?2"
+
+        # IL6 → ["IL", "6"]
+        p = _build_punctuation_regex("IL6")
+        assert p == r"IL[- ]?6"
 
     def test_empty_returns_none(self):
         """Empty and whitespace-only inputs return None."""


### PR DESCRIPTION
Sub-split tokens like CDK2 → ["CDK", "2"] and PDE4A → ["PDE", "4A"] at letter→digit boundaries so the regex also matches hyphenated forms (CDK-2, PDE-4A). All-letter tokens (EGFR, BRAF) remain unsplit.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement / refactor
- [ ] Documentation
- [ ] Tests
- [ ] CI / infrastructure

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `uv run pytest tests/unit/ -v` passes
- [ ] Tested manually (describe below)

<!-- If applicable, describe how you tested the changes -->
