### PR TITLE
Fix default GTM model resolution (HF repo id + .pkl fallback)

### DIFF
--- a/src/cs_copilot/tools/chemography/gtm_operations.py
+++ b/src/cs_copilot/tools/chemography/gtm_operations.py
@@ -287,6 +287,12 @@ def resolve_gtm_model_path(
 
     Returns:
         Resolved path to the GTM model file
+
+    Raises:
+        FileNotFoundError: If no explicit path was provided and the default
+            model could not be located in the local cache or downloaded from
+            HuggingFace. The error message lists every source that was tried
+            and why it failed.
     """
     # Priority 1: Explicit file path (unless use_default is True)
     if gtm_file and not use_default:
@@ -303,9 +309,7 @@ def resolve_gtm_model_path(
     # Priority 3: Default model resolution
     logger.debug("Resolving default GTM model path")
 
-    # Try S3 assets first (check for any .pkl.gz file)
-    # This is a placeholder - actual S3 discovery would need to be implemented
-    # based on your S3 storage structure
+    tried: list[str] = []
 
     # Try default directory
     default_path = Path(DEFAULT_GTM_MODEL_PATH).expanduser()
@@ -318,6 +322,12 @@ def resolve_gtm_model_path(
                 model_path = str(matches[0])
                 logger.info(f"Found default GTM model at: {model_path}")
                 return model_path
+        tried.append(
+            f"default cache {default_path} "
+            f"(no files matching {list(GTM_MODEL_SUFFIXES)})"
+        )
+    else:
+        tried.append(f"default cache {default_path} (directory does not exist)")
 
     # Try Hugging Face download
     try:
@@ -341,14 +351,27 @@ def resolve_gtm_model_path(
                 logger.info(f"Downloaded GTM model to: {model_path}")
                 return model_path
 
+        tried.append(
+            f"HuggingFace repo {HUGGINGFACE_GTM_REPO} "
+            f"(download succeeded but no files matching {list(GTM_MODEL_SUFFIXES)})"
+        )
     except ImportError:
         logger.warning("huggingface_hub not available, cannot download from HuggingFace")
+        tried.append("HuggingFace (huggingface_hub package not installed)")
     except Exception as e:
         logger.warning(f"Failed to download from HuggingFace: {e}")
+        tried.append(f"HuggingFace repo {HUGGINGFACE_GTM_REPO} ({e})")
 
-    # If nothing worked, return the default path (may not exist)
-    logger.warning(f"Could not resolve GTM model, using default path: {default_path}")
-    return str(default_path)
+    bullets = "\n  - ".join(tried)
+    raise FileNotFoundError(
+        "Could not resolve a default GTM model. Tried:\n"
+        f"  - {bullets}\n"
+        "Fix by one of:\n"
+        "  - Pass an explicit model path via the `gtm_file`/`gtm_model` argument.\n"
+        f"  - Place a GTM model file (e.g. *.pkl.gz) in {default_path}.\n"
+        f"  - Ensure the HuggingFace repo {HUGGINGFACE_GTM_REPO} exists and is accessible "
+        "(run `huggingface-cli login` if it is gated)."
+    )
 
 
 def load_gtm_model(gtm_model_path: str) -> Any:
@@ -850,9 +873,18 @@ def data_load_and_prep(dataset: str, gtm_model: str):
 
     gtm = None
     try:
-        with S3.open(gtm_saved_file, "rb") as f:
-            with gzip.open(f, "rb") as gz:
-                gtm = dill.load(gz)
+        try:
+            with S3.open(gtm_saved_file, "rb") as f:
+                with gzip.open(f, "rb") as gz:
+                    gtm = dill.load(gz)
+        except gzip.BadGzipFile:
+            # File is not actually gzipped (e.g. a plain .pkl from HuggingFace);
+            # fall back to loading as a regular pickle.
+            logger.warning(
+                f"File {gtm_saved_file} is not gzipped. Loading as regular pickle file."
+            )
+            with S3.open(gtm_saved_file, "rb") as f:
+                gtm = dill.load(f)
     except ModuleNotFoundError as e:
         logger.error(f"Error loading GTM model: {e}")
         raise
@@ -928,9 +960,18 @@ def project_data_on_gtm(dataset_file: str, gtm_model_file: str) -> str:
     # -------------------------------------------------------------------------
     logger.debug("Loading GTM model for compatibility check...")
     try:
-        with S3.open(gtm_saved_file, "rb") as f:
-            with gzip.open(f, "rb") as gz:
-                gtm = dill.load(gz)
+        try:
+            with S3.open(gtm_saved_file, "rb") as f:
+                with gzip.open(f, "rb") as gz:
+                    gtm = dill.load(gz)
+        except gzip.BadGzipFile:
+            # File is not actually gzipped (e.g. a plain .pkl from HuggingFace);
+            # fall back to loading as a regular pickle.
+            logger.warning(
+                f"File {gtm_saved_file} is not gzipped. Loading as regular pickle file."
+            )
+            with S3.open(gtm_saved_file, "rb") as f:
+                gtm = dill.load(f)
     except FileNotFoundError as e:
         raise FileNotFoundError(f"GTM model file not found: {gtm_saved_file}") from e
     except ModuleNotFoundError as e:

--- a/src/cs_copilot/tools/constants.py
+++ b/src/cs_copilot/tools/constants.py
@@ -82,7 +82,7 @@ HUGGINGFACE_PEPTIDE_WAE_REPO = "axelrolov/wae_peptides"
 
 # GTM model defaults
 DEFAULT_GTM_MODEL_PATH = os.path.expanduser("~/.cache/cs_copilot/models/gtm")
-HUGGINGFACE_GTM_REPO = "axelrolov/cs_copilot-gtm"
+HUGGINGFACE_GTM_REPO = "axelrolov/chemspacecopilot-gtm"
 
 # DBAASP antimicrobial peptide data
 DEFAULT_DBAASP_DATA_PATH = os.path.expanduser("~/.cache/cs_copilot/data/dbaasp_data.csv")

--- a/tests/unit/test_gtm_plots.py
+++ b/tests/unit/test_gtm_plots.py
@@ -646,3 +646,33 @@ def test_gtm_toolkit_create_activity_landscapes_forwards_renderer(monkeypatch):
 
     assert captured["renderer"] == "plotly"
     assert captured["gtm_model"] == "resolved/model.pkl.gz"
+
+
+def test_resolve_gtm_model_path_raises_when_no_source_available(monkeypatch, tmp_path):
+    """When every resolution strategy fails, raise a clear FileNotFoundError.
+
+    Guards against regressing to the old behavior of silently returning the
+    default cache *directory*, which downstream code would then mangle into a
+    bogus ``<cache>/gtm.pkl.gz`` path and surface a confusing file-not-found
+    error far from the real cause.
+    """
+
+    empty_cache = tmp_path / "empty_gtm_cache"
+    monkeypatch.setattr(gtm_operations, "DEFAULT_GTM_MODEL_PATH", str(empty_cache))
+
+    fake_hf = ModuleType("huggingface_hub")
+
+    def _fail_download(**_kwargs):
+        raise RuntimeError("404 Repository Not Found")
+
+    fake_hf.snapshot_download = _fail_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        gtm_operations.resolve_gtm_model_path(use_default=True)
+
+    message = str(exc_info.value)
+    assert "Could not resolve a default GTM model" in message
+    assert str(empty_cache) in message
+    assert "404 Repository Not Found" in message
+    assert gtm_operations.HUGGINGFACE_GTM_REPO in message


### PR DESCRIPTION
- Correct HUGGINGFACE_GTM_REPO to axelrolov/chemspacecopilot-gtm (the old id axelrolov/cs_copilot-gtm returned 404).
- resolve_gtm_model_path now raises FileNotFoundError with an actionable message listing every source tried, instead of silently returning the cache directory path that downstream code mangled into a confusing "<cache>/gtm.pkl.gz" error.
- data_load_and_prep and project_data_on_gtm fall back to plain dill.load on gzip.BadGzipFile, matching load_gtm_model, so the uncompressed .pkl file shipped by the HF repo loads correctly.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- List the key changes -->

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement / refactor
- [ ] Documentation
- [ ] Tests
- [ ] CI / infrastructure

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `uv run pytest tests/unit/ -v` passes
- [ ] Tested manually (describe below)

<!-- If applicable, describe how you tested the changes -->
