### PR TITLE
48 docker compose broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,28 @@ WORKDIR /app
 # Dependency metadata (for Docker layer caching)
 COPY pyproject.toml uv.lock README.md ./
 
-# Install Python dependencies via uv
-RUN uv sync --frozen --no-dev
+# Install third-party dependencies only (not the local project) so this
+# expensive layer is cached independently of source-code changes.
+# The SynPlanner family has no aarch64 Linux wheels; skip them all.
+# SynPlanner is lazy-loaded so it is never imported unless a retrosynthesis
+# tool is explicitly invoked.
+RUN uv sync --frozen --no-dev --no-install-project \
+    --no-install-package synplanner \
+    --no-install-package cgrtools-stable \
+    --no-install-package chython-synplan \
+    --no-install-package chytorch-synplan \
+    --no-install-package chytorch-rxnmap-synplan
 
 # Application source
 COPY . .
+
+# Install the local cs_copilot package into the already-populated venv
+RUN uv sync --frozen --no-dev \
+    --no-install-package synplanner \
+    --no-install-package cgrtools-stable \
+    --no-install-package chython-synplan \
+    --no-install-package chytorch-synplan \
+    --no-install-package chytorch-rxnmap-synplan
 
 # Prisma / Node dependencies
 COPY package.json ./
@@ -53,4 +70,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["uv", "run", "chainlit", "run", "chainlit_app.py", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "--no-sync", "chainlit", "run", "chainlit_app.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+ARG TARGETARCH
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -29,26 +31,34 @@ COPY pyproject.toml uv.lock README.md ./
 
 # Install third-party dependencies only (not the local project) so this
 # expensive layer is cached independently of source-code changes.
-# The SynPlanner family has no aarch64 Linux wheels; skip them all.
+# The SynPlanner family has no aarch64 Linux wheels; skip them only on arm64.
 # SynPlanner is lazy-loaded so it is never imported unless a retrosynthesis
 # tool is explicitly invoked.
-RUN uv sync --frozen --no-dev --no-install-project \
-    --no-install-package synplanner \
-    --no-install-package cgrtools-stable \
-    --no-install-package chython-synplan \
-    --no-install-package chytorch-synplan \
-    --no-install-package chytorch-rxnmap-synplan
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        uv sync --frozen --no-dev --no-install-project \
+            --no-install-package synplanner \
+            --no-install-package cgrtools-stable \
+            --no-install-package chython-synplan \
+            --no-install-package chytorch-synplan \
+            --no-install-package chytorch-rxnmap-synplan; \
+    else \
+        uv sync --frozen --no-dev --no-install-project; \
+    fi
 
 # Application source
 COPY . .
 
 # Install the local cs_copilot package into the already-populated venv
-RUN uv sync --frozen --no-dev \
-    --no-install-package synplanner \
-    --no-install-package cgrtools-stable \
-    --no-install-package chython-synplan \
-    --no-install-package chytorch-synplan \
-    --no-install-package chytorch-rxnmap-synplan
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        uv sync --frozen --no-dev \
+            --no-install-package synplanner \
+            --no-install-package cgrtools-stable \
+            --no-install-package chython-synplan \
+            --no-install-package chytorch-synplan \
+            --no-install-package chytorch-rxnmap-synplan; \
+    else \
+        uv sync --frozen --no-dev; \
+    fi
 
 # Prisma / Node dependencies
 COPY package.json ./


### PR DESCRIPTION
## Summary

Restores docker functionality on DGX Spark

## Changes

- Deactivation of the Synplanner agent if the container is being built on aarch64

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement / refactor
- [ ] Documentation
- [ ] Tests
- [ ] CI / infrastructure

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `uv run pytest tests/unit/ -v` passes
- [x] Tested manually (describe below)

docker compose build chainlit-app
should finish correctly